### PR TITLE
Tests: enable format checker

### DIFF
--- a/message-api-schema-validator/schema_validator_test_suite.py
+++ b/message-api-schema-validator/schema_validator_test_suite.py
@@ -1,4 +1,6 @@
+import sys
 from unittest import TestSuite, TextTestRunner
+
 from tests.header import MessageHeaderTest
 from tests.metadata import MetadataCreateRequestTest, MetadataReadRequestTest, MetadataReadResponseTest, \
     MetadataUpdateRequestTest, MetadataDeleteRequestTest
@@ -29,4 +31,5 @@ def suite():
 if __name__ == '__main__':
     runner = TextTestRunner()
     test_suite = suite()
-    runner.run(test_suite)
+    result = runner.run(test_suite)
+    sys.exit(1 if len(result.errors) > 0 else 0)

--- a/message-api-schema-validator/tests/abstract_schema_validator_test.py
+++ b/message-api-schema-validator/tests/abstract_schema_validator_test.py
@@ -1,5 +1,5 @@
 from json import load
-from jsonschema import validate, RefResolver
+from jsonschema import validate, FormatChecker, RefResolver
 from abc import ABCMeta, abstractmethod
 from sys import argv
 from unittest import TestCase
@@ -61,7 +61,8 @@ class AbstractSchemaValidatorTest(TestCase):
                     schema_id: self.get_json(schema_path)
                     for schema_id, schema_path in self.schema_id_path_pairs
                 }
-            )
+            ),
+            format_checker=FormatChecker()
         )
 
     def get_json(self, file_name):

--- a/messages/body/metadata/create/request.json
+++ b/messages/body/metadata/create/request.json
@@ -60,7 +60,7 @@
   ],
   "objectDate": [
     {
-      "dateValue": "string",
+      "dateValue": "2002-10-02T10:00:00-05:00",
       "dateType": 1
     }
   ],
@@ -112,7 +112,7 @@
       "fileSize": 1,
       "fileLabel": "string",
       "fileDateCreated": {
-        "dateValue": "string",
+        "dateValue": "2002-10-02T10:00:00-05:00",
         "dateType": 1
       },
       "fileRights": {
@@ -147,7 +147,7 @@
       "fileHasMimeType": true,
       "fileDateModified": [
         {
-          "dateValue": "string",
+          "dateValue": "2002-10-02T10:00:00-05:00",
           "dateType": 1
         }
       ],
@@ -165,13 +165,13 @@
       "fileUploadStatus": 1,
       "fileStorageStatus": 1,
       "fileLastDownloaded": {
-        "dateValue": "string",
+        "dateValue": "2002-10-02T10:00:00-05:00",
         "dateType": 1
       },
       "fileTechnicalAttributes": [
         "string"
       ],
-      "fileStorageLocation": "string",
+      "fileStorageLocation": "https://tools.ietf.org/html/rfc3986",
       "fileStorageType": 1
     }
   ]

--- a/messages/body/metadata/read/response.json
+++ b/messages/body/metadata/read/response.json
@@ -60,7 +60,7 @@
   ],
   "objectDate": [
     {
-      "dateValue": "string",
+      "dateValue": "2002-10-02T10:00:00-05:00",
       "dateType": 1
     }
   ],
@@ -112,7 +112,7 @@
       "fileSize": 1,
       "fileLabel": "string",
       "fileDateCreated": {
-        "dateValue": "string",
+        "dateValue": "2002-10-02T10:00:00-05:00",
         "dateType": 1
       },
       "fileRights": {
@@ -147,7 +147,7 @@
       "fileHasMimeType": true,
       "fileDateModified": [
         {
-          "dateValue": "string",
+          "dateValue": "2002-10-02T10:00:00-05:00",
           "dateType": 1
         }
       ],
@@ -165,13 +165,13 @@
       "fileUploadStatus": 1,
       "fileStorageStatus": 1,
       "fileLastDownloaded": {
-        "dateValue": "string",
+        "dateValue": "2002-10-02T10:00:00-05:00",
         "dateType": 1
       },
       "fileTechnicalAttributes": [
         "string"
       ],
-      "fileStorageLocation": "string",
+      "fileStorageLocation": "https://tools.ietf.org/html/rfc3986",
       "fileStorageType": 1
     }
   ]

--- a/messages/body/metadata/update/request.json
+++ b/messages/body/metadata/update/request.json
@@ -60,7 +60,7 @@
   ],
   "objectDate": [
     {
-      "dateValue": "string",
+      "dateValue": "2002-10-02T10:00:00-05:00",
       "dateType": 1
     }
   ],
@@ -112,7 +112,7 @@
       "fileSize": 1,
       "fileLabel": "string",
       "fileDateCreated": {
-        "dateValue": "string",
+        "dateValue": "2002-10-02T10:00:00-05:00",
         "dateType": 1
       },
       "fileRights": {
@@ -147,7 +147,7 @@
       "fileHasMimeType": true,
       "fileDateModified": [
         {
-          "dateValue": "string",
+          "dateValue": "2002-10-02T10:00:00-05:00",
           "dateType": 1
         }
       ],
@@ -165,13 +165,13 @@
       "fileUploadStatus": 1,
       "fileStorageStatus": 1,
       "fileLastDownloaded": {
-        "dateValue": "string",
+        "dateValue": "2002-10-02T10:00:00-05:00",
         "dateType": 1
       },
       "fileTechnicalAttributes": [
         "string"
       ],
-      "fileStorageLocation": "string",
+      "fileStorageLocation": "https://tools.ietf.org/html/rfc3986",
       "fileStorageType": 1
     }
   ]

--- a/messages/message.json
+++ b/messages/message.json
@@ -85,7 +85,7 @@
     ],
     "objectDate": [
       {
-        "dateValue": "string",
+        "dateValue": "2002-10-02T10:00:00-05:00",
         "dateType": 1
       }
     ],
@@ -137,7 +137,7 @@
         "fileSize": 1,
         "fileLabel": "string",
         "fileDateCreated": {
-          "dateValue": "string",
+          "dateValue": "2002-10-02T10:00:00-05:00",
           "dateType": 1
         },
         "fileRights": {
@@ -172,7 +172,7 @@
         "fileHasMimeType": true,
         "fileDateModified": [
           {
-            "dateValue": "string",
+            "dateValue": "2002-10-02T10:00:00-05:00",
             "dateType": 1
           }
         ],
@@ -190,13 +190,13 @@
         "fileUploadStatus": 1,
         "fileStorageStatus": 1,
         "fileLastDownloaded": {
-          "dateValue": "string",
+          "dateValue": "2002-10-02T10:00:00-05:00",
           "dateType": 1
         },
         "fileTechnicalAttributes": [
           "string"
         ],
-        "fileStorageLocation": "string",
+        "fileStorageLocation": "https://tools.ietf.org/html/rfc3986",
         "fileStorageType": 1
       }
     ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+isodate
 jsonschema
 pre-commit
 pylint
+rfc3987


### PR DESCRIPTION
This replaces https://github.com/JiscRDSS/rdss-message-api-specification/pull/67.

---

These are the changes introduced in this commit:

- Return exit code in the test runner so CI catches errors otherwise they will
  fail silently.
- Hook a `jsonschema.FormatChecker` instance into the validator used in the
  test suite so we can catch format validation issues.
- Fix existing validation issues (`date-time` and `uri`).
- Add `isodate` and `rfc3987` to the `requirements.txt` file. These are optional
  dependencies of `jsonschema` that enable support for `uri` and `date-time`
  formats.