### PR TITLE
messages: use real UUIDs

### DIFF
--- a/messages/body/metadata/create/request.json
+++ b/messages/body/metadata/create/request.json
@@ -1,10 +1,10 @@
 {
-  "objectUuid": "string",
+  "objectUuid": "13256c13-ed37-453b-ba93-6a97268700b5",
   "objectTitle": "string",
   "objectPersonRole": [
     {
       "person": {
-        "personUuid": "string",
+        "personUuid": "0cef4168-1934-4b44-a8e2-d0dce19f93e8",
         "personIdentifier": [
           {
             "personIdentifierValue": "string",
@@ -106,7 +106,7 @@
   ],
   "objectFile": [
     {
-      "fileUuid": "string",
+      "fileUuid": "92853a85-b116-4db9-b720-56d5e7a04ac4",
       "fileIdentifier": "string",
       "fileName": "string",
       "fileSize": 1,
@@ -137,7 +137,7 @@
       },
       "fileChecksum": [
         {
-          "checksumUuid": "string",
+          "checksumUuid": "a17673d9-4634-4b8c-8d88-6250b97d9260",
           "checksumType": 1,
           "checksumValue": "string"
         }

--- a/messages/body/metadata/delete/request.json
+++ b/messages/body/metadata/delete/request.json
@@ -1,3 +1,3 @@
 {
-  "objectUuid": "string"
+  "objectUuid": "1fa0e504-0d30-4b4b-9a39-4fc8b586963b"
 }

--- a/messages/body/metadata/read/request.json
+++ b/messages/body/metadata/read/request.json
@@ -1,3 +1,3 @@
 {
-  "objectUuid": "string"
+  "objectUuid": "6d79812c-482f-442c-b603-9009f6258a17"
 }

--- a/messages/body/metadata/read/response.json
+++ b/messages/body/metadata/read/response.json
@@ -1,10 +1,10 @@
 {
-  "objectUuid": "string",
+  "objectUuid": "2443725c-3da8-4a0b-86a1-45a92662f505",
   "objectTitle": "string",
   "objectPersonRole": [
     {
       "person": {
-        "personUuid": "string",
+        "personUuid": "2a38d053-f1b1-49af-97a2-1846ef989935",
         "personIdentifier": [
           {
             "personIdentifierValue": "string",
@@ -106,7 +106,7 @@
   ],
   "objectFile": [
     {
-      "fileUuid": "string",
+      "fileUuid": "abe826f3-ccff-4eb5-8209-ebc13b0a7d0e",
       "fileIdentifier": "string",
       "fileName": "string",
       "fileSize": 1,
@@ -137,7 +137,7 @@
       },
       "fileChecksum": [
         {
-          "checksumUuid": "string",
+          "checksumUuid": "2f705cf3-4473-44e1-9352-1ea8ffead062",
           "checksumType": 1,
           "checksumValue": "string"
         }

--- a/messages/body/metadata/update/request.json
+++ b/messages/body/metadata/update/request.json
@@ -1,10 +1,10 @@
 {
-  "objectUuid": "string",
+  "objectUuid": "4704f353-ca71-407a-a181-643633ec2bce",
   "objectTitle": "string",
   "objectPersonRole": [
     {
       "person": {
-        "personUuid": "string",
+        "personUuid": "8e8ee11d-7540-469b-88f1-2dedb98202a7",
         "personIdentifier": [
           {
             "personIdentifierValue": "string",
@@ -106,7 +106,7 @@
   ],
   "objectFile": [
     {
-      "fileUuid": "string",
+      "fileUuid": "5f483b4a-8e2c-4dd2-9361-a4fa7047b8c6",
       "fileIdentifier": "string",
       "fileName": "string",
       "fileSize": 1,
@@ -137,7 +137,7 @@
       },
       "fileChecksum": [
         {
-          "checksumUuid": "string",
+          "checksumUuid": "7b466a8e-aae7-44d2-ad69-953e1efdd5f8",
           "checksumType": 1,
           "checksumValue": "string"
         }

--- a/messages/example.json
+++ b/messages/example.json
@@ -1,6 +1,6 @@
 {
   "messageHeader": {
-    "messageId": "string",
+    "messageId": "be8eff14-a92b-429e-80b8-0ec4594d72c0",
     "correlationId": "string",
     "messageClass": "Command",
     "messageType": "MetadataCreate",
@@ -10,7 +10,7 @@
       "expirationTimestamp": ""
     },
     "messageSequence": {
-      "sequence": "string",
+      "sequence": "1529d794-10cf-44c1-86d4-2d7b70dbbb15",
       "position": 1,
       "total": 1
     },

--- a/messages/header/example.json
+++ b/messages/header/example.json
@@ -1,5 +1,5 @@
 {
-  "messageId": "string",
+  "messageId": "ef1ecf64-6813-4f80-94a3-93ee0802b435",
   "correlationId": "string",
   "messageClass": "Command",
   "messageType": "MetadataCreate",
@@ -9,7 +9,7 @@
     "expirationTimestamp": ""
   },
   "messageSequence": {
-    "sequence": "string",
+    "sequence": "c9b3b53b-8f58-41b6-bc0e-ef549cfd897b",
     "position": 1,
     "total": 1
   },


### PR DESCRIPTION
I have some code in the AM channel adapter that uses the sample messages in this repository as text fixtures. With https://github.com/JiscRDSS/rdss-archivematica-channel-adapter/pull/71 the use of UUIDs is necessary or the messages will not be decoded.