### PR TITLE
id -> $id in schemas to match Draft-06 spec.

### DIFF
--- a/message-api-schema-validator/rdss_schema/validator.py
+++ b/message-api-schema-validator/rdss_schema/validator.py
@@ -13,7 +13,7 @@ class RDSSSchemaValidator(object):
             '',
             {},
             store={
-                schema['id']: schema
+                schema['$id']: schema
                 for schema in self._schemas
             }
         )
@@ -27,12 +27,12 @@ class RDSSSchemaValidator(object):
 
     def _generate_definition_schemas(self, schema_json):
         schema = schema_json['$schema']
-        base_id = schema_json['id']
+        base_id = schema_json['$id']
         schemas = {}
         for definition in schema_json.get('definitions', {}).keys():
             full_id = base_id + '/definitions/' + definition
             definition_schema = {
-                'id': full_id,
+                '$id': full_id,
                 '$schema': schema,
                 '$ref': full_id
             }

--- a/schemas/article.json
+++ b/schemas/article.json
@@ -1,5 +1,5 @@
 {
-  "id": "https://www.jisc.ac.uk/rdss/schema/article.json/#",
+  "$id": "https://www.jisc.ac.uk/rdss/schema/article.json/#",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "definitions": {
     "Article": {

--- a/schemas/common_entities.json
+++ b/schemas/common_entities.json
@@ -1,5 +1,5 @@
 {
-  "id": "https://www.jisc.ac.uk/rdss/schema/common_entities.json/#",
+  "$id": "https://www.jisc.ac.uk/rdss/schema/common_entities.json/#",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "definitions": {
     "Coverage": {

--- a/schemas/dataset.json
+++ b/schemas/dataset.json
@@ -1,5 +1,5 @@
 {
-  "id": "https://www.jisc.ac.uk/rdss/schema/dataset.json/#",
+  "$id": "https://www.jisc.ac.uk/rdss/schema/dataset.json/#",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "definitions": {
     "Dataset": {

--- a/schemas/enumeration.json
+++ b/schemas/enumeration.json
@@ -1,5 +1,5 @@
 {
-  "id": "https://www.jisc.ac.uk/rdss/schema/enumeration.json/#",
+  "$id": "https://www.jisc.ac.uk/rdss/schema/enumeration.json/#",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "definitions": {
     "AccessType": {

--- a/schemas/information_package.json
+++ b/schemas/information_package.json
@@ -1,5 +1,5 @@
 {
-  "id": "https://www.jisc.ac.uk/rdss/schema/information_package.json/#",
+  "$id": "https://www.jisc.ac.uk/rdss/schema/information_package.json/#",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "definitions": {
     "InformationPackage": {

--- a/schemas/intellectual_asset.json
+++ b/schemas/intellectual_asset.json
@@ -1,5 +1,5 @@
 {
-  "id": "https://www.jisc.ac.uk/rdss/schema/intellectual_asset.json/#",
+  "$id": "https://www.jisc.ac.uk/rdss/schema/intellectual_asset.json/#",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "definitions": {
     "File": {

--- a/schemas/material_asset.json
+++ b/schemas/material_asset.json
@@ -1,5 +1,5 @@
 {
-  "id": "https://www.jisc.ac.uk/rdss/schema/material_asset.json/#",
+  "$id": "https://www.jisc.ac.uk/rdss/schema/material_asset.json/#",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "definitions": {
     "Organisation": {

--- a/schemas/message/header.json
+++ b/schemas/message/header.json
@@ -1,5 +1,5 @@
 {
-  "id": "https://www.jisc.ac.uk/rdss/schema/message/header.json/#",
+  "$id": "https://www.jisc.ac.uk/rdss/schema/message/header.json/#",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "definitions": {
     "Header": {

--- a/schemas/message/metadata/create_request.json
+++ b/schemas/message/metadata/create_request.json
@@ -1,5 +1,5 @@
 {
-  "id": "https://www.jisc.ac.uk/rdss/schema/message/metadata/create_request.json/#",
+  "$id": "https://www.jisc.ac.uk/rdss/schema/message/metadata/create_request.json/#",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "definitions": {
     "MetadataCreateRequest": {

--- a/schemas/message/metadata/delete_request.json
+++ b/schemas/message/metadata/delete_request.json
@@ -1,5 +1,5 @@
 {
-  "id": "https://www.jisc.ac.uk/rdss/schema/message/metadata/delete_request.json/#",
+  "$id": "https://www.jisc.ac.uk/rdss/schema/message/metadata/delete_request.json/#",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "definitions": {
     "MetadataDeleteRequest": {

--- a/schemas/message/metadata/read_request.json
+++ b/schemas/message/metadata/read_request.json
@@ -1,5 +1,5 @@
 {
-  "id": "https://www.jisc.ac.uk/rdss/schema/message/metadata/read_request.json/#",
+  "$id": "https://www.jisc.ac.uk/rdss/schema/message/metadata/read_request.json/#",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "definitions": {
     "MetadataReadRequest": {

--- a/schemas/message/metadata/read_response.json
+++ b/schemas/message/metadata/read_response.json
@@ -1,5 +1,5 @@
 {
-  "id": "https://www.jisc.ac.uk/rdss/schema/message/metadata/read_response.json/#",
+  "$id": "https://www.jisc.ac.uk/rdss/schema/message/metadata/read_response.json/#",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "definitions": {
     "MetadataReadResponse": {

--- a/schemas/message/metadata/update_request.json
+++ b/schemas/message/metadata/update_request.json
@@ -1,5 +1,5 @@
 {
-  "id": "https://www.jisc.ac.uk/rdss/schema/message/metadata/update_request.json/#",
+  "$id": "https://www.jisc.ac.uk/rdss/schema/message/metadata/update_request.json/#",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "definitions": {
     "MetadataUpdateRequest": {

--- a/schemas/message/preservation/preservation_event_request.json
+++ b/schemas/message/preservation/preservation_event_request.json
@@ -1,5 +1,5 @@
 {
-  "id": "https://www.jisc.ac.uk/rdss/schema/message/preservation/preservation_event_request.json/#",
+  "$id": "https://www.jisc.ac.uk/rdss/schema/message/preservation/preservation_event_request.json/#",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "definitions": {
     "PreservationEventRequest": {

--- a/schemas/research_object.json
+++ b/schemas/research_object.json
@@ -1,5 +1,5 @@
 {
-  "id": "https://www.jisc.ac.uk/rdss/schema/research_object.json/#",
+  "$id": "https://www.jisc.ac.uk/rdss/schema/research_object.json/#",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "definitions": {
     "ResearchObject": {

--- a/schemas/thesis_dissertation.json
+++ b/schemas/thesis_dissertation.json
@@ -1,5 +1,5 @@
 {
-  "id": "https://www.jisc.ac.uk/rdss/schema/thesis_dissertation.json/#",
+  "$id": "https://www.jisc.ac.uk/rdss/schema/thesis_dissertation.json/#",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "definitions": {
     "ThesisDissertation": {

--- a/schemas/types.json
+++ b/schemas/types.json
@@ -1,5 +1,5 @@
 {
-  "id": "https://www.jisc.ac.uk/rdss/schema/types.json/#",
+  "$id": "https://www.jisc.ac.uk/rdss/schema/types.json/#",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "definitions": {
     "NonEmptyString": {


### PR DESCRIPTION
For context: http://json-schema.org/draft-06/json-schema-release-notes.html
I'd missed this, and suspect that other validators will pick up on it where the python one hasn't.